### PR TITLE
Remove question mark operator, roll to 1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.5 - 2016-01-13
+### Fixed
+
+* [1.3.4 with `?` operator breaks semver](https://github.com/slog-rs/term/issues/6) - fix allows builds on stable Rust back to 1.11
+
 ## 1.3.4 - 2016-12-27
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-term"
-version = "1.3.4"
+version = "1.3.5"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Unix terminal drain and formatter for slog-rs"
 keywords = ["slog", "logging", "log", "term"]

--- a/lib.rs
+++ b/lib.rs
@@ -198,12 +198,12 @@ impl<D: Decorator> Format<D> {
                 let (mut line, _) = ser.finish();
 
                 if self.should_print(line, indent) {
-                    write!(line, "\n")?;
-                    io.write_all(line)?;
+                    try!(write!(line, "\n"));
+                    try!(io.write_all(line));
                 }
                 Ok(())
             });
-            res?;
+            try!(res);
             indent += 1;
         }
 


### PR DESCRIPTION
Changes the question mark operator back to `try!` for now, and updates CHANGELOG and Cargo.toml to version 1.3.5.

Tested on Rust stable versions back to 1.11 successfully.