### PR TITLE
Fix https://github.com/slog-rs/term/issues/8

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1086,7 +1086,7 @@ impl<'a> RecordDecorator for TermRecordDecorator<'a> {
             }
             .map_err(term_error_to_io_error)
     }
-    
+
     fn start_key(&mut self) -> io::Result<()> {
         match self.term {
                 &mut AnyTerminal::Stdout(ref mut term) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1086,14 +1086,22 @@ impl<'a> RecordDecorator for TermRecordDecorator<'a> {
             }
             .map_err(term_error_to_io_error)
     }
-
+    
     fn start_key(&mut self) -> io::Result<()> {
         match self.term {
                 &mut AnyTerminal::Stdout(ref mut term) => {
-                    term.attr(term::Attr::Bold)
+                    if term.supports_attr(term::Attr::Bold) {
+                        term.attr(term::Attr::Bold)
+                    } else {
+                        term.fg(term::color::BRIGHT_WHITE)
+                    }
                 }
                 &mut AnyTerminal::Stderr(ref mut term) => {
-                    term.attr(term::Attr::Bold)
+                    if term.supports_attr(term::Attr::Bold) {
+                        term.attr(term::Attr::Bold)
+                    } else {
+                        term.fg(term::color::BRIGHT_WHITE)
+                    }
                 }
             }
             .map_err(term_error_to_io_error)


### PR DESCRIPTION
Check support before `term.attr(bold)`, use fallback `term.fg(bright_white)` when `term.attr(bold)` is not supported.