### PR TITLE
fix: avoid panic when no terminal is available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ isatty = "0.1"
 chrono = "0.3"
 thread_local = "0.3.3"
 term = "0.4.5"
+error-chain = "0.10.0"
 
 [dev-dependencies]
 slog-async = "~2.0.0-2"

--- a/examples/compact-color.rs
+++ b/examples/compact-color.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 mod common;
 
 fn main() {
-    let decorator = slog_term::TermDecorator::new().build();
+    let decorator = slog_term::TermDecorator::new().build().unwrap();
     let drain = slog_term::CompactFormat::new(decorator).build().fuse();
     let drain = slog_async::Async::new(drain).build().fuse();
 

--- a/examples/full-color.rs
+++ b/examples/full-color.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 mod common;
 
 fn main() {
-    let decorator = slog_term::TermDecorator::new().build();
+    let decorator = slog_term::TermDecorator::new().build().unwrap();
     let drain = slog_term::FullFormat::new(decorator).build().fuse();
     let drain = slog_async::Async::new(drain).build().fuse();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,8 @@
+error_chain! {
+    errors {
+        /// No terminal available
+        NoTerminal {
+            display("No terminal available")
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ extern crate isatty;
 extern crate chrono;
 extern crate thread_local;
 extern crate term;
+#[macro_use]
+extern crate error_chain;
 
 use slog::*;
 use slog::Drain;
@@ -41,6 +43,10 @@ use std::cell::RefCell;
 use std::io::Write as IoWrite;
 use std::panic::{UnwindSafe, RefUnwindSafe};
 use std::result;
+
+mod error;
+use error::{Result, ErrorKind};
+pub use error::Error;
 // }}}
 
 // {{{ Decorator
@@ -964,6 +970,8 @@ enum AnyTerminal {
     Stdout(Box<term::StdoutTerminal>),
     /// Stderr terminal
     Stderr(Box<term::StderrTerminal>),
+    /// No terminal available
+    None,
 }
 
 /// `TermDecorator` builder
@@ -971,24 +979,44 @@ pub struct TermDecoratorBuilder(AnyTerminal);
 
 impl TermDecoratorBuilder {
     fn new() -> Self {
-        TermDecoratorBuilder(AnyTerminal::Stderr(term::stderr().unwrap()))
+        match term::stderr() {
+            Some(term) => TermDecoratorBuilder(AnyTerminal::Stderr(term)),
+            None => TermDecoratorBuilder(AnyTerminal::None),
+        }
     }
 
     /// Output to `stderr`
     pub fn stderr(mut self) -> Self {
-        self.0 = AnyTerminal::Stderr(term::stderr().unwrap());
+        match term::stderr() {
+            Some(term) => {
+                self.0 = AnyTerminal::Stderr(term);
+            }
+            None => {
+                self.0 = AnyTerminal::None;
+            }
+        }
         self
     }
 
     /// Output to `stdout`
     pub fn stdout(mut self) -> Self {
-        self.0 = AnyTerminal::Stdout(term::stdout().unwrap());
+        match term::stdout() {
+            Some(term) => {
+                self.0 = AnyTerminal::Stdout(term);
+            }
+            None => {
+                self.0 = AnyTerminal::None;
+            }
+        }
         self
     }
 
     /// Build `TermDecorator`
-    pub fn build(self) -> TermDecorator {
-        TermDecorator(RefCell::new(self.0))
+    pub fn build(self) -> Result<TermDecorator> {
+        match self.0 {
+            AnyTerminal::None => Err(ErrorKind::NoTerminal.into()),
+            term => Ok(TermDecorator(RefCell::new(term))),
+        }
     }
 }
 
@@ -1053,6 +1081,7 @@ impl<'a> io::Write for TermRecordDecorator<'a> {
         match self.term {
             &mut AnyTerminal::Stdout(ref mut term) => term.write(buf),
             &mut AnyTerminal::Stderr(ref mut term) => term.write(buf),
+            &mut AnyTerminal::None => unreachable!(),
         }
     }
 
@@ -1060,6 +1089,7 @@ impl<'a> io::Write for TermRecordDecorator<'a> {
         match self.term {
             &mut AnyTerminal::Stdout(ref mut term) => term.flush(),
             &mut AnyTerminal::Stderr(ref mut term) => term.flush(),
+            &mut AnyTerminal::None => unreachable!(),
         }
     }
 }
@@ -1082,6 +1112,7 @@ impl<'a> RecordDecorator for TermRecordDecorator<'a> {
         match self.term {
                 &mut AnyTerminal::Stdout(ref mut term) => term.reset(),
                 &mut AnyTerminal::Stderr(ref mut term) => term.reset(),
+                &mut AnyTerminal::None => unreachable!(),
             }
             .map_err(term_error_to_io_error)
     }
@@ -1091,6 +1122,7 @@ impl<'a> RecordDecorator for TermRecordDecorator<'a> {
         match self.term {
                 &mut AnyTerminal::Stdout(ref mut term) => term.fg(color),
                 &mut AnyTerminal::Stderr(ref mut term) => term.fg(color),
+                &mut AnyTerminal::None => unreachable!(),
             }
             .map_err(term_error_to_io_error)
     }
@@ -1111,6 +1143,7 @@ impl<'a> RecordDecorator for TermRecordDecorator<'a> {
                         term.fg(term::color::BRIGHT_WHITE)
                     }
                 }
+                &mut AnyTerminal::None => unreachable!(),
             }
             .map_err(term_error_to_io_error)
     }


### PR DESCRIPTION
`TermDecoratorBuilder::build` now returns a `Result<TermDecorator>`
instead of `TermDecorator`. This new behavior allows one to check
whether or not a terminal is supported in the environment instead of
causing a `panic` like before.

[breaking-change]