### PR TITLE
Add writer that plays nicely with rust's test harness

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1219,6 +1219,23 @@ impl<'a> RecordDecorator for TermRecordDecorator<'a> {
 
 // }}}
 
+// {{{ TestStdoutWriter
+/// Replacement for `std::io::stdout()` for when output capturing by rust's test harness is
+/// required.
+pub struct TestStdoutWriter;
+
+impl io::Write for TestStdoutWriter {
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        print!("{}", std::str::from_utf8(data)
+                              .map_err(|x| io::Error::new(io::ErrorKind::InvalidData, x))?);
+        Ok(data.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        io::stdout().flush()
+    }
+}
+// }}}
+
 // {{{ Helpers
 /// Create a `CompactFormat` drain with default settings
 pub fn term_compact() -> CompactFormat<TermDecorator> {


### PR DESCRIPTION
The following code

```rust
#[macro_use] extern crate slog;
extern crate slog_term;

use slog::Drain;
use std::panic::{UnwindSafe, RefUnwindSafe};
use std::sync::Mutex;

struct SafeDrain<D>(Mutex<D>); // Don't really know why this is required or if there isn't a better way
impl<D: Drain> Drain for SafeDrain<D> {
    type Ok = D::Ok;
    type Err = D::Err;
    fn log(&self, r: &slog::Record, v: &slog::OwnedKVList) -> Result<D::Ok, D::Err> {
        self.0.lock().unwrap().log(r, v)
    }
}
impl<D: Drain> UnwindSafe for SafeDrain<D> {}
impl<D: Drain> RefUnwindSafe for SafeDrain<D> {}

#[cfg(test)]
mod tests {
    use super::*;

    #[test]
    fn it_works() {
        let logger = slog::Logger::root(
            SafeDrain(Mutex::new(
                slog_term::CompactFormat::new(
                    slog_term::PlainDecorator::new(std::io::stdout())
                ).build().fuse()
            )),
            o!()
        );
        info!(logger, "test");
    }
}
```

logs output without going through rust's test harness' output capturing.

This PR adds a `Writer` alternative to `std::io::stdout()` that makes logged messages go through rust's test harness.