### PR TITLE
Update term to 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.24.1
+  - 1.32.0
 
 script:
   - make all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ slog = "2"
 atty = "0.2"
 chrono = "0.4"
 thread_local = "0.3.3"
-term = "0.5.1"
+term = "0.6"
 
 [dev-dependencies]
 slog-async = "2"


### PR DESCRIPTION
The motivation here is the following chain:

```
memoffset v0.2.1
└── crossbeam-epoch v0.6.1
    └── crossbeam v0.5.0
        └── rust-argon2 v0.5.0
            └── redox_users v0.3.1
                └── dirs v1.0.5
                    └── term v0.5.2
                        └── slog-term v2.4.1
````

where memoffset is subject to:

```
ID:      RUSTSEC-2019-0011
Crate:   memoffset
Version: 0.2.1
Date:    2019-07-16
URL:     https://github.com/Gilnaa/memoffset/issues/9#issuecomment-505461490
Title:   Flaw in offset_of and span_of causes SIGILL, potential memory unsafety
Solution: upgrade to: >= 0.5.0
```

I've also raised https://github.com/sru-systems/rust-argon2/pull/19 to fix this a different way, in case bumping the version here isn't acceptable.