### PR TITLE
Add support for slog/nested-values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,18 @@ repository = "https://github.com/slog-rs/term"
 readme = "README.md"
 edition = "2018"
 
+[features]
+nested-values = ["erased-serde", "serde", "serde_json", "slog/nested-values"]
+
 [dependencies]
 slog = "2"
 atty = "0.2"
 chrono = "0.4"
 thread_local = "1"
 term = "0.6"
+erased-serde = {version = "0.3", optional = true }
+serde = {version = "1.0", optional = true }
+serde_json = {version = "1.0", optional = true }
 
 [dev-dependencies]
 slog-async = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -676,6 +676,23 @@ impl<'a> slog::ser::Serializer for Serializer<'a> {
         s!(self, key, val);
         Ok(())
     }
+    #[cfg(feature = "nested-values")]
+    fn emit_serde(
+        &mut self,
+        key: Key,
+        val: &dyn slog::SerdeValue,
+    ) -> slog::Result {
+        let mut writer = Vec::new();
+        serde::ser::Serialize::serialize(
+            val.as_serde(),
+            &mut serde_json::Serializer::new(&mut writer),
+        )
+        .map_err(|e| std::io::Error::from(e))?;
+        let val =
+            std::str::from_utf8(&writer).expect("serde JSON is always UTF-8");
+        s!(self, key, val);
+        Ok(())
+    }
 }
 // }}}
 


### PR DESCRIPTION
slog gained support for the `nested-values` feature in https://github.com/slog-rs/slog/pull/152.  slog-json implemented it in https://github.com/slog-rs/json/pull/7.

slog-term didn't support it.  This PR adds support for it by serializing nested values into JSON and outputting that.

JSON might be a controversial choice - feedback welcome!  We need some way of representing a nested set of values into a concise but human-readable structure and JSON felt like a good option.