### PR TITLE
Fall back on terminals that don't support color

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1342,8 +1342,20 @@ impl<'a> RecordDecorator for TermRecordDecorator<'a> {
             return Ok(());
         }
         match self.term {
-            &mut AnyTerminal::Stdout(ref mut term) => term.reset(),
-            &mut AnyTerminal::Stderr(ref mut term) => term.reset(),
+            &mut AnyTerminal::Stdout(ref mut term) => {
+                if term.supports_reset() {
+                    term.reset()
+                } else {
+                    Ok(())
+                }
+            }
+            &mut AnyTerminal::Stderr(ref mut term) => {
+                if term.supports_reset() {
+                    term.reset()
+                } else {
+                    Ok(())
+                }
+            }
             &mut AnyTerminal::FallbackStdout
             | &mut AnyTerminal::FallbackStderr => Ok(()),
         }
@@ -1357,10 +1369,18 @@ impl<'a> RecordDecorator for TermRecordDecorator<'a> {
         let color = TermDecorator::level_to_color(self.level);
         match self.term {
             &mut AnyTerminal::Stdout(ref mut term) => {
-                term.fg(color as term::color::Color)
+                if term.supports_color() {
+                    term.fg(color as term::color::Color)
+                } else {
+                    Ok(())
+                }
             }
             &mut AnyTerminal::Stderr(ref mut term) => {
-                term.fg(color as term::color::Color)
+                if term.supports_color() {
+                    term.fg(color as term::color::Color)
+                } else {
+                    Ok(())
+                }
             }
             &mut AnyTerminal::FallbackStdout
             | &mut AnyTerminal::FallbackStderr => Ok(()),
@@ -1376,15 +1396,19 @@ impl<'a> RecordDecorator for TermRecordDecorator<'a> {
             &mut AnyTerminal::Stdout(ref mut term) => {
                 if term.supports_attr(term::Attr::Bold) {
                     term.attr(term::Attr::Bold)
-                } else {
+                } else if term.supports_color() {
                     term.fg(term::color::BRIGHT_WHITE)
+                } else {
+                    Ok(())
                 }
             }
             &mut AnyTerminal::Stderr(ref mut term) => {
                 if term.supports_attr(term::Attr::Bold) {
                     term.attr(term::Attr::Bold)
-                } else {
+                } else if term.supports_color() {
                     term.fg(term::color::BRIGHT_WHITE)
+                } else {
+                    Ok(())
                 }
             }
             &mut AnyTerminal::FallbackStdout


### PR DESCRIPTION
Some terminals don't actually support color/reset. For example, on arch, my terminfo database shows me this:

```
$ TERM=dumb infocmp
#       Reconstructed via infocmp from file: /usr/share/terminfo/d/dumb
dumb|80-column dumb tty,
        am,
        cols#80,
        bel=^G, cr=\r, cud1=\n, ind=\n,
```

Note that there's no color or sgr escape codes. (Real world example of this can be found in https://github.com/tummychow/git-absorb/issues/29 - emacs runs things under `TERM=dumb` when capturing their output to a buffer/eshell.)

The `term` crate will obey whatever terminfo tells it. So if you try to output color on this terminal, the `term` crate will return an error, which slog-term dutifully returns. For example, in this repo, if I run:

```
$ TERM=dumb cargo run --example full-color
   Compiling slog-term v2.5.0 (/tmp/term)
    Finished dev [unoptimized + debuginfo] target(s) in 1.23s
     Running `target/debug/examples/full-color`
thread '<unnamed>' panicked at 'slog::Fuse Drain: Custom { kind: Other, error: "term error: operation not supported by the terminal" }', <::std::macros::panic macros>:5:6
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR allows slog-term to fall back to uncolored output when it's on a terminal that doesn't actually support it. After this PR, the example succeeds, and it produces uncolored output instead:

```
$ TERM=dumb cargo run --example full-color
   Compiling slog-term v2.5.0 (/tmp/term)
    Finished dev [unoptimized + debuginfo] target(s) in 1.26s
     Running `target/debug/examples/full-color`
May 23 19:12:48.345 INFO starting, port: 8080, host: localhost, version: 0.5
May 23 19:12:48.346 INFO listening, port: 8080, host: localhost, version: 0.5
May 23 19:12:48.346 DEBG connected, port: 42381, peer_addr: 82.9.9.9, port: 8080, host: localhost, version: 0.5
...
```

I chose to put the color support check in the functions that actually print the escape codes instead of in `should_use_color()`, so the logger will fall back even if you use `TermDecorator.new().force_color()`. But I'm happy to adjust this if maintainers prefer otherwise.