### PR TITLE
Update the term dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-term"
-version = "2.6.0"
+version = "2.7.0"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Unix terminal drain and formatter for slog-rs"
 keywords = ["slog", "logging", "log", "term"]
@@ -19,7 +19,7 @@ slog = "2"
 atty = "0.2"
 chrono = "0.4"
 thread_local = "1"
-term = "0.6"
+term = "0.7"
 erased-serde = {version = "0.3", optional = true }
 serde = {version = "1.0", optional = true }
 serde_json = {version = "1.0", optional = true }


### PR DESCRIPTION
This change updates the `term` dependency and also bumps minor version
because `term` bumped MSRV to 1.36.

Note: this causes `cfg_if` to be duplicated when testing. It'll be resolved when `slog-async` updates.