### PR TITLE
replace chrono with newer time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ nested-values = ["erased-serde", "serde", "serde_json", "slog/nested-values"]
 [dependencies]
 slog = "2"
 atty = "0.2"
-time = "0.2"
+time = { version = "0.3", default-features = false, features = ["std", "macros", "formatting", "local-offset"] }
 thread_local = "1"
 term = "0.7"
 erased-serde = {version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ nested-values = ["erased-serde", "serde", "serde_json", "slog/nested-values"]
 [dependencies]
 slog = "2"
 atty = "0.2"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
+time = "0.2"
 thread_local = "1"
 term = "0.7"
 erased-serde = {version = "0.3", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1089,14 +1089,16 @@ const TIMESTAMP_FORMAT: &str = "%b %d %H:%M:%S%.3f";
 ///
 /// The exact format used, is still subject to change.
 pub fn timestamp_local(io: &mut dyn io::Write) -> io::Result<()> {
-    write!(io, "{}", chrono::Local::now().format(TIMESTAMP_FORMAT))
+    let now: time::OffsetDateTime = std::time::SystemTime::now().into();
+    write!(io, "{}", now.format(TIMESTAMP_FORMAT))
 }
 
 /// Default UTC timestamp function
 ///
 /// The exact format used, is still subject to change.
 pub fn timestamp_utc(io: &mut dyn io::Write) -> io::Result<()> {
-    write!(io, "{}", chrono::Utc::now().format(TIMESTAMP_FORMAT))
+    let now = time::OffsetDateTime::now_utc();
+    write!(io, "{}", now.format(TIMESTAMP_FORMAT))
 }
 // }}}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1083,14 +1083,14 @@ where
 {
 }
 
-const TIMESTAMP_FORMAT: &str = "%b %d %H:%M:%S%.3f";
+const TIMESTAMP_FORMAT: &[time::format_description::FormatItem] = time::macros::format_description!("[month repr:short] [day] [hour repr:24]:[minute]:[second].[subsecond digits:3]");
 
 /// Default local timezone timestamp function
 ///
 /// The exact format used, is still subject to change.
 pub fn timestamp_local(io: &mut dyn io::Write) -> io::Result<()> {
     let now: time::OffsetDateTime = std::time::SystemTime::now().into();
-    write!(io, "{}", now.format(TIMESTAMP_FORMAT))
+    write!(io, "{}", now.format(TIMESTAMP_FORMAT).map_err(convert_time_fmt_error)?)
 }
 
 /// Default UTC timestamp function
@@ -1098,8 +1098,12 @@ pub fn timestamp_local(io: &mut dyn io::Write) -> io::Result<()> {
 /// The exact format used, is still subject to change.
 pub fn timestamp_utc(io: &mut dyn io::Write) -> io::Result<()> {
     let now = time::OffsetDateTime::now_utc();
-    write!(io, "{}", now.format(TIMESTAMP_FORMAT))
+    write!(io, "{}", now.format(TIMESTAMP_FORMAT).map_err(convert_time_fmt_error)?)
 }
+fn convert_time_fmt_error(cause: time::error::Format) -> io::Error {
+    return io::Error::new(io::ErrorKind::Other, cause);
+}
+
 // }}}
 
 // {{{ Plain


### PR DESCRIPTION
This is to avoid a potential security issue:
(edit: replaced https://rustsec.org/advisories/RUSTSEC-2020-0071 AKA CVE-2020-26235 with:)
https://rustsec.org/advisories/RUSTSEC-2020-0159 AKA CVE-2020-26235