### PR TITLE
Prepare v2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.8.1 - 2022-02-01
+### Fixed
+
+* Disable default features on chrono to address RUSTSEC-2020-0071 aka CVE-2020-26235
+* Use SPDX compliant license name
+
 ## 2.8.0 - 2021-02-10
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-term"
-version = "2.8.0"
+version = "2.8.1"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Unix terminal drain and formatter for slog-rs"
 keywords = ["slog", "logging", "log", "term"]


### PR DESCRIPTION
I want to avoid accidentally pulling unused `time` crate in my project to speed up compilation and avoid CVE-2020-26235. Security issue was already fixed in 79bfa8cf17d8f99600e9e7370d5b7f0d30f554bf few months ago, so I would like to be able to use it.

I think it's going to close the discussion in #39 as well.