### PR TITLE
Attempt to switch from `term` to `termcolor`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ slog = "2"
 atty = "0.2"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 thread_local = "1"
-term = "0.7"
+termcolor = "1"
+thiserror = "1"
 erased-serde = {version = "0.3", optional = true }
 serde = {version = "1.0", optional = true }
 serde_json = {version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ atty = "0.2"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 thread_local = "1"
 termcolor = "1"
-thiserror = "1"
 erased-serde = {version = "0.3", optional = true }
 serde = {version = "1.0", optional = true }
 serde_json = {version = "1.0", optional = true }


### PR DESCRIPTION
As discussed in slog-rs/slog#267 it appears that the `term` crate is unmaintained.

This is a *draft* for switching to term color:

**Advantages:**
- `termcolor::Write` extends `std::io::Write` (and has unified stderr/stdout times) so we don't have to use the nasty enum
- `termcolor` has no custom error type. It just uses `std::io::Error`

In general this seems to clean things up significantly. However, it has the following caveats:

**Disadvantages/Limitations**:
- `termcolor` has no counterpart to `suports_bold`. We can't ask "do you support bold?". We can only ask "do you support colors?"


**Potential Alternatives:**
I think it's good to think about potential alternatives. One alternative is updating to a more modern version of `term` (like [term 0.7](https://docs.rs/term/0.7/term/))

Here are some other crates listed on the issue:
- [crossterm](https://github.com/crossterm-rs/crossterm)
- [termcolor](https://crates.io/crates/termcolor) (this thing)
- [yansi](https://crates.io/crates/yansi)

`termcolor` (this PR) definitely seems to have less features than `term` does.

I think `crossterm` looks extremely promising.

I don't think we should go with `yansi` because windows support seems second-class.