### PR TITLE
remove unused time features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ nested-values = ["erased-serde", "serde", "serde_json", "slog/nested-values"]
 [dependencies]
 slog = "2"
 atty = "0.2"
-time = { version = "0.3", default-features = false, features = ["std", "macros", "formatting", "local-offset"] }
+time = { version = "0.3", default-features = false, features = ["macros", "formatting"] }
 thread_local = "1"
 term = "0.7"
 erased-serde = {version = "0.3", optional = true }


### PR DESCRIPTION
leaving out `std` doesn't really do anything because `formatting` implies `std` per <https://docs.rs/crate/time/0.3.0/features>.

However `local-offset` is unused here, and since this is the feature that reintroduces thread-safety shenanigans it seems worthwhile to avoid it if we can.

It may be that what this really means is that the current implementation of `timestamp_local()` is in fact not doing anything to localise the timestamp, and that's a bug.  I'm in the UTC timezone, so it's not quite straightforward for me to test this!

Edit: yeah, I'm pretty sure that there is no localisation going on.  Probably what you really want is 
```diff
-    let now: time::OffsetDateTime = std::time::SystemTime::now().into();
+    let now = time::OffsetDateTime::now_local();
```
the [implementation](https://github.com/time-rs/time/blob/ffd53f0c25599fd6c46060a524c900c09d5838b9/src/offset_date_time.rs#L60) of ` time::OffsetDateTime::now_utc()` is exactly what you [currently have](https://github.com/slog-rs/term/blob/c95050f7be2c9bf83a0a140e838fd4856e943afc/src/lib.rs#L1092) in `timestamp_local()`

I'll submit a second MR and you can choose!