### PR TITLE
security: Avoid using buggy atty crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ nested-values = ["erased-serde", "serde", "serde_json", "slog/nested-values"]
 
 [dependencies]
 slog = "2"
-atty = "0.2"
+is-terminal = "0.4"
 time = { version = "0.3", default-features = false, features = ["macros", "formatting"] }
 thread_local = "1"
 term = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,12 @@ use std::io::Write as IoWrite;
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::result;
 use std::{fmt, io, mem, sync};
+
+// TODO: Should probably look into `std::io::IsTerminal` if/when that becomes stable
+// See tracking issue rust-lang/rust#98070
+//
+// This should really be an issue we file on the `is-terminal` crate
+use is_terminal::IsTerminal;
 // }}}
 
 // {{{ Decorator
@@ -1332,8 +1338,8 @@ enum AnyTerminal {
 impl AnyTerminal {
     fn should_use_color(&self) -> bool {
         match *self {
-            AnyTerminal::Stdout { .. } => atty::is(atty::Stream::Stdout),
-            AnyTerminal::Stderr { .. } => atty::is(atty::Stream::Stderr),
+            AnyTerminal::Stdout { .. } => std::io::stdout().is_terminal(),
+            AnyTerminal::Stderr { .. } => std::io::stderr().is_terminal(),
             AnyTerminal::FallbackStdout => false,
             AnyTerminal::FallbackStderr => false,
         }


### PR DESCRIPTION
Switches to newer `is-terminal` crate instead.
This functionality is also availible on the nightly Rust stdlib as a `std::io::IsTerminal` trait.

Avoids RUSTSEC-2021-0145 (softprops/atty#50)
Fixes slog-rs/slog#319

Based on the information in the vulnerability database, I don't consider this a particularly serious bug.

> In practice however, the pointer won't be unaligned
   unless a custom global allocator is used.