### PR TITLE
Avoid atty and bump MSRV to 1.63

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
     strategy:
       fail-fast: false # Even if one job fails we still want to see the other ones
       matrix:
-        # 1.53 is MSRV. Keep in sync with Cargo.toml
-        rust: [1.53, stable, nightly]
+        # 1.63 is MSRV. Keep in sync with Cargo.toml
+        rust: [1.63, stable, nightly]
         # NOTE: Features to test must be specified manually. They are applied to all versions seperately.
        #
         # This has the advantage of being more flexibile and thorough
@@ -47,5 +47,7 @@ jobs:
       # NOTE: We only run `cargo test`. No need for a seperate `cargo check`
       - name: Test
         run: |
-          cargo test --verbose --features "${{ matrix.features }}"
+          # Pin a time version with a compatible MSRV
+          cargo update --package time --precise 0.3.20
+          cargo test --locked --verbose --features "${{ matrix.features }}"
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- next-url -->
 ## [Unreleased](https://github.com/slog-rs/term/compare/v2.8.1...HEAD) - ReleaseDate
+* Switch from `atty` to `is_terminal`
+    * Avoids [RUSTSEC-2021-0145](https://rustsec.org/advisories/RUSTSEC-2021-0145)
+* BREAKING: Bump MSRV to 1.63
 
 ## 2.9.0 - 2022-02-20
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ nested-values = ["erased-serde", "serde", "serde_json", "slog/nested-values"]
 
 [dependencies]
 slog = "2"
-atty = "0.2"
+is-terminal = "0.4"
 time = { version = "0.3", default-features = false, features = ["macros", "formatting"] }
 thread_local = "1"
 term = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 #
 # The first version of Cargo that supports this field was in Rust 1.56.0.
 # In older releases, the field will be ignored, and Cargo will display a warning.
-rust-version = "1.53"
+rust-version = "1.63"
 
 [features]
 nested-values = ["erased-serde", "serde", "serde_json", "slog/nested-values"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,12 @@ use std::io::Write as IoWrite;
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::result;
 use std::{fmt, io, mem, sync};
+
+// TODO: Should probably look into `std::io::IsTerminal` if/when that becomes stable
+// See tracking issue rust-lang/rust#98070
+//
+// This should really be an issue we file on the `is-terminal` crate
+use is_terminal::IsTerminal;
 // }}}
 
 // {{{ Decorator
@@ -1332,8 +1338,8 @@ enum AnyTerminal {
 impl AnyTerminal {
     fn should_use_color(&self) -> bool {
         match *self {
-            AnyTerminal::Stdout { .. } => atty::is(atty::Stream::Stdout),
-            AnyTerminal::Stderr { .. } => atty::is(atty::Stream::Stderr),
+            AnyTerminal::Stdout { .. } => std::io::stdout().is_terminal(),
+            AnyTerminal::Stderr { .. } => std::io::stderr().is_terminal(),
             AnyTerminal::FallbackStdout => false,
             AnyTerminal::FallbackStderr => false,
         }


### PR DESCRIPTION
This is https://github.com/slog-rs/term/pull/45 with an extra commit bumping the MSRV. I think this is necessary to match is_terminal's MSRV - https://github.com/sunfishcode/is-terminal/blob/main/Cargo.toml#L16.

CI passes on my fork: https://github.com/rkd-msw/term/actions/runs/5714633882