### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ nested-values = ["erased-serde", "serde", "serde_json", "slog/nested-values"]
 [dependencies]
 slog = "2"
 is-terminal = "0.4"
-time = { version = "0.3", default-features = false, features = ["macros", "formatting"] }
+time = { version = "0.3.47", default-features = false, features = ["macros", "formatting"] }
 thread_local = "1"
 term = "1"
 erased-serde = {version = "0.3", optional = true }


### PR DESCRIPTION
Bumps the dependency to at least 0.3.47 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2026-0009.html)

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)